### PR TITLE
JCN-135-soporte-elasticsearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 ### Added
 - `elasticsearch` DBDriver support
+### Changed
+- `validateConfig()` method now allows a config without `database` field, but stills veryfing it when exists.
 
 ## [1.3.3] - 2019-07-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - `elasticsearch` DBDriver support
 ### Changed
-- `validateConfig()` method now allows a config without `database` field, but stills veryfing it when exists.
+- `dbTypes` getter now includes package name and database requirement
+- `validateConfig()` method rejects when the database config is invalid only when the DBDriver requires it.
 
 ## [1.3.3] - 2019-07-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- `elasticsearch` DBDriver support
+
 ## [1.3.3] - 2019-07-17
 ### Fixed
 - Updated Settings package to use correct settings path

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The package allows you to have 2 sources for configs.
 
 - `type [String]` (required): Database driver type, example `"mysql"`.
 - `host [String]` (required): Database connection host.
-- `database [String]` (required): Database name for connection, example `"myDB"`.
+- `database [String]` (optional): Database name for connection, example `"myDB"`.
 - `user [String]` (optional): Database login user name.
 - `password [String]` (optional): Database login password.
 - `port [Number]` (optional): Database connection port.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ The package allows you to have 2 sources for configs.
 - `database [String]`: Database name for connection, example `"myDB"`.  
 
 #### Required fields
+* `type`: Always required
+* `host`: Always required
 * `database`: Some DBDrivers may require this field, for example, MongoDB and MySQL requires it, but elasticsearch doesn't.
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -52,10 +52,13 @@ The package allows you to have 2 sources for configs.
 
 - `type [String]` (required): Database driver type, example `"mysql"`.
 - `host [String]` (required): Database connection host.
-- `database [String]` (optional): Database name for connection, example `"myDB"`.
 - `user [String]` (optional): Database login user name.
 - `password [String]` (optional): Database login password.
 - `port [Number]` (optional): Database connection port.
+- `database [String]`: Database name for connection, example `"myDB"`.  
+
+#### Required fields
+* `database`: Some DBDrivers may require this field, for example, MongoDB and MySQL requires it, but elasticsearch doesn't.
 
 ### Environment Variables
 You can easly have the connection configs in environment variables using the followin structure.
@@ -75,7 +78,7 @@ DB_[KEY]_PORT
 #### Required fields
 * HOST
 * TYPE
-* DATABASE
+* DATABASE: Some DBDrivers may require this field, such as MongoDB and MySQL.
 
 #### Example
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ npm install @janiscommerce/database-dispatcher
 # Then install all the drivers that you need.
 npm install --save @janiscommerce/mysql
 npm install --save @janiscommerce/mongodb
+npm install --save @janiscommerce/elasticsearch
 ```
 
 ## Settings
@@ -36,6 +37,11 @@ The package allows you to have 2 sources for configs.
 			"type": "mongodb",
 			"host": "http://other-host-name.com",
 			"database": "my-database"
+			// ...
+		},
+		"another": {
+			"type": "elasticsearch",
+			"host": "http://another-host-name.com",
 			// ...
 		}
 	}

--- a/lib/database-dispatcher.js
+++ b/lib/database-dispatcher.js
@@ -108,7 +108,7 @@ class DatabaseDispatcher {
 		if(!this.dbTypes[dbConfig.type])
 			throw new DatabaseDispatcherError(`DB type '${dbConfig.type}' is not allowed`, DatabaseDispatcherError.codes.DB_CONFIG_TYPE_NOT_ALLOWED);
 
-		if(typeof dbConfig.database !== 'string')
+		if(typeof dbConfig.database !== 'undefined' && typeof dbConfig.database !== 'string')
 			throw new DatabaseDispatcherError('Invalid DB database in config', DatabaseDispatcherError.codes.DB_CONFIG_INVALID_DATABASE);
 	}
 

--- a/lib/database-dispatcher.js
+++ b/lib/database-dispatcher.js
@@ -7,7 +7,8 @@ const DatabaseDispatcherError = require('./database-dispatcher-error');
 
 const DB_DRIVERS = {
 	mysql: '@janiscommerce/mysql',
-	mongodb: '@janiscommerce/mongodb'
+	mongodb: '@janiscommerce/mongodb',
+	elasticsearch: '@janiscommerce/elasticsearch'
 };
 
 class DatabaseDispatcher {

--- a/lib/database-dispatcher.js
+++ b/lib/database-dispatcher.js
@@ -6,15 +6,31 @@ const Settings = require('@janiscommerce/settings');
 const DatabaseDispatcherError = require('./database-dispatcher-error');
 
 const DB_DRIVERS = {
-	mysql: '@janiscommerce/mysql',
-	mongodb: '@janiscommerce/mongodb',
-	elasticsearch: '@janiscommerce/elasticsearch'
+	mysql: {
+		package: '@janiscommerce/mysql',
+		databaseRequired: true
+	},
+	mongodb: {
+		package: '@janiscommerce/mongodb',
+		databaseRequired: true
+	},
+	elasticsearch: {
+		package: '@janiscommerce/elasticsearch'
+	}
 };
 
 class DatabaseDispatcher {
 
 	static get dbTypes() {
 		return DB_DRIVERS;
+	}
+
+	static getDBDriverPackage(dbType) {
+		return this.dbTypes[dbType].package;
+	}
+
+	static isDatabaseRequired(dbType) {
+		return this.dbTypes[dbType].databaseRequired;
 	}
 
 	static set config(config) {
@@ -108,8 +124,8 @@ class DatabaseDispatcher {
 		if(!this.dbTypes[dbConfig.type])
 			throw new DatabaseDispatcherError(`DB type '${dbConfig.type}' is not allowed`, DatabaseDispatcherError.codes.DB_CONFIG_TYPE_NOT_ALLOWED);
 
-		if(typeof dbConfig.database !== 'undefined' && typeof dbConfig.database !== 'string')
-			throw new DatabaseDispatcherError('Invalid DB database in config', DatabaseDispatcherError.codes.DB_CONFIG_INVALID_DATABASE);
+		if(this.isDatabaseRequired(dbConfig.type) && typeof dbConfig.database !== 'string')
+			throw new DatabaseDispatcherError('Database is required in config', DatabaseDispatcherError.codes.DB_CONFIG_INVALID_DATABASE);
 	}
 
 	/**
@@ -123,9 +139,10 @@ class DatabaseDispatcher {
 		let DBDriver;
 
 		try {
-			DBDriver = require(path.join(process.cwd(), 'node_modules', this.dbTypes[config.type])); //eslint-disable-line
+			DBDriver = require(path.join(process.cwd(), 'node_modules', this.getDBDriverPackage(config.type))); //eslint-disable-line
 		} catch(err) {
-			throw new DatabaseDispatcherError(`Package "${this.dbTypes[config.type]}" not installed.\nPlease run: npm install ${this.dbTypes[config.type]}`,
+			throw new DatabaseDispatcherError(
+				`Package "${this.getDBDriverPackage(config.type)}" not installed.\nPlease run: npm install ${this.getDBDriverPackage(config.type)}`,
 				DatabaseDispatcherError.codes.DB_DRIVER_NOT_INSTALLED);
 		}
 

--- a/tests/database-dispatcher-test.js
+++ b/tests/database-dispatcher-test.js
@@ -264,12 +264,13 @@ describe('DatabaseDispatcher', function() {
 			assertThrows(DatabaseDispatcherError.codes.DB_CONFIG_TYPE_NOT_ALLOWED, 'database-not-allowed-type');
 		});
 
-		it('should reject when database config miss the database', function() {
+		it('should reject when database config contains an invalid database', function() {
 
 			mockConfig({
 				'database-no-database': {
 					host: 'my-host',
-					type: 'mysql'
+					type: 'mysql',
+					database: ['no-string-database']
 				}
 			});
 
@@ -298,6 +299,26 @@ describe('DatabaseDispatcher', function() {
 					host: 'my-host',
 					type: 'mysql',
 					database: 'db-name'
+				}
+			});
+
+			databaseMock();
+
+			let dbDriver;
+
+			assert.doesNotThrow(() => {
+				dbDriver = DatabaseDispatcher.getDatabaseByKey('my-database');
+			});
+
+			assert(dbDriver.constructor.name === 'DBDriverMock');
+		});
+
+		it('should return a driver instance if is installed when the config does\'t include a database field', function() {
+
+			mockConfig({
+				'my-database': {
+					host: 'my-host',
+					type: 'elasticsearch'
 				}
 			});
 

--- a/tests/database-dispatcher-test.js
+++ b/tests/database-dispatcher-test.js
@@ -50,6 +50,7 @@ describe('DatabaseDispatcher', function() {
 	const databaseMock = dbDriverMock => {
 		mock(path.join(process.cwd(), 'node_modules', '@janiscommerce/mysql'), dbDriverMock || DBDriverMock);
 		mock(path.join(process.cwd(), 'node_modules', '@janiscommerce/mongodb'), dbDriverMock || DBDriverMock);
+		mock(path.join(process.cwd(), 'node_modules', '@janiscommerce/elasticsearch'), dbDriverMock || DBDriverMock);
 	};
 
 	const mockConfig = dbConfig => sandbox.stub(Settings, 'get').returns(dbConfig);
@@ -61,6 +62,14 @@ describe('DatabaseDispatcher', function() {
 			user: 'root',
 			password: 'foobar',
 			database: 'my_db',
+			port: '1234'
+		},
+
+		bar: {
+			type: 'elasticsearch',
+			host: 'foo',
+			user: 'root',
+			password: 'foobar',
 			port: '1234'
 		},
 


### PR DESCRIPTION
**JCN-135 SOPORTE ELASTICSEARCH**
JCN-135 Agregar soporte para elasticsearch

**LINK AL TICKET**
[https://fizzmod.atlassian.net/browse/JCN-135](https://fizzmod.atlassian.net/browse/JCN-135)

**DESCRIPCIÓN DEL REQUERIMIENTO**
2.1. Se debe agregar al elasticsearch como `DBDriver` soportado

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se aplicaron los cambios solicitados