### PR TITLE
QUICK-fix-mensaje-de-error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Original error message when can't create the DB Driver instance
+
 ## [2.0.0] - 2019-09-11
 ### Added
 - `getDatabaseByClient()` method to return database instance from a client object

--- a/lib/database-dispatcher.js
+++ b/lib/database-dispatcher.js
@@ -175,7 +175,7 @@ class DatabaseDispatcher {
 		try {
 			return new DBDriver(config);
 		} catch(err) {
-			throw new DatabaseDispatcherError(`Package "${config.type}" error creating instance`,
+			throw new DatabaseDispatcherError(`Package "${config.type}" error creating instance: ${err.message}`,
 				DatabaseDispatcherError.codes.INVALID_DB_DRIVER);
 		}
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@janiscommerce/database-dispatcher",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
**DESCRIPCIÓN DEL REQUERIMIENTO**
Agregar el mensaje de error original cuando el dispatcher falla al crear la instancia del driver.

**DESCRIPCIÓN DE LA SOLUCIÓN**
Se agregó el mensaje original al error de creación de instancias del DB Driver